### PR TITLE
Adds "btn modal" class to editor button.

### DIFF
--- a/plg_editors-xtd_podcastmanager/podcastmanager.php
+++ b/plg_editors-xtd_podcastmanager/podcastmanager.php
@@ -75,6 +75,7 @@ class PlgButtonPodcastManager extends JPlugin
 		$button = new JObject;
 		$button->modal = true;
 		$button->link = $link;
+		$button->class = "btn";
 		$button->text = JText::_('PLG_EDITORS-XTD_PODCASTMANAGER_BUTTON');
 		$button->name = 'broadcast';
 		$button->title = JText::_('PLG_EDITORS-XTD_PODCASTMANAGER_BUTTON_TOOLTIP');


### PR DESCRIPTION
Using Joomla! 3.1.5 Stable, the podcast button for the editor is invisible, due to a missing Bootstrap `btn` class.
